### PR TITLE
Fix student id search

### DIFF
--- a/internals/lib/lib.go
+++ b/internals/lib/lib.go
@@ -33,9 +33,9 @@ const (
 // Input is a type alias to the input field of an exercise.
 type Input = map[string]any
 
-// GetStudentId returns the student id given in the argument `id`, or in the STUDENT_ID file
-// searched upwards from the current directory, or from the environment variable `STUDENT_ID`, or
-// an error is no id was found
+// GetStudentId returns the student id given in the argument `id`, from the environment variable
+// `STUDENT_ID`, or from the STUDENT_ID file searched upwards from the current directory (in that
+// order), or an error is no id was found. All student ids are converted to upper case.
 func GetStudentId(id *string) (string, error) {
 	student, err := findStudentId(id)
 	if err != nil {

--- a/internals/lib/util.go
+++ b/internals/lib/util.go
@@ -27,12 +27,15 @@ func findFile(dir, name string) (string, error) {
 	}
 }
 
-// findStudentId returns the raw student id given in the argument `id`, or in the STUDENT_ID file
-// searched upwards from the current directory, or from the environment variable `STUDENT_ID`, or
-// an error is no id was found or the student id is set as the default
 func findStudentId(id *string) (string, error) {
 	if id != nil && *id != "" {
-		return *id, nil
+		return strings.ToUpper(*id), nil
+	}
+
+	// env overrides stundent-id file
+	env := os.Getenv(StudentEnvVar)
+	if env != "" {
+		return strings.ToUpper(strings.TrimSpace(env)), nil
 	}
 
 	dir, err := os.Getwd()
@@ -46,12 +49,7 @@ func findStudentId(id *string) (string, error) {
 			return "", fmt.Errorf("internal error: could not find student-id file %q returned by findFile",
 				StudentIdFile)
 		}
-		return strings.TrimSpace(string(dat)), nil
-	}
-
-	env := os.Getenv(StudentEnvVar)
-	if env != "" {
-		return strings.TrimSpace(env), nil
+		return strings.ToUpper(strings.TrimSpace(string(dat))), nil
 	}
 
 	return "", fmt.Errorf("no student id file found searhing up from %q", dir)


### PR DESCRIPTION
Student ID from environment variable now overrides the student ID taken from a file. This makes checking solutions easier. In addition, student IDs are now converted to upper-case to avoid case sensitivity issues.